### PR TITLE
adding methods / paths to add friends and list friends

### DIFF
--- a/SpyDuh.API/Controllers/SpyController.cs
+++ b/SpyDuh.API/Controllers/SpyController.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Text;
 
 namespace SpyDuh.API.Controllers
 {
@@ -24,6 +25,46 @@ namespace SpyDuh.API.Controllers
         {
             return Ok(_repo.GetAll());
         }
-         
+
+        [HttpPatch("{spyGuid}/AddFriend/{friendGuid}")]
+        public IActionResult AddFriend(Guid spyGuid, Guid friendGuid)
+        {
+            var spyObj = _repo.GetSpy(spyGuid);
+            var friendObj = _repo.GetSpy(friendGuid);
+            StringBuilder returnStr = new StringBuilder("");
+            if (spyObj != null && friendObj != null)
+            {
+                if (!spyObj.Friends.Contains(friendGuid))
+                {
+                    spyObj.Friends.Add(friendGuid);
+                    return Ok($"Friend with Id {friendGuid} added.\n");
+                }
+                else return BadRequest($"Friend with Id: {friendGuid} already in friend list\n");
+            }
+            if (spyObj == null) returnStr.Append($"Spy with id: {spyGuid} not found\n");
+            if (friendObj == null) returnStr.Append($"Friend with id: {spyGuid} not found\n");
+
+            return NotFound(returnStr.ToString());
+        }
+
+        [HttpGet("{spyGuid}/ListFriends")]
+        public IActionResult ListFriends(Guid spyGuid)
+        {
+            var spyObj = _repo.GetSpy(spyGuid);
+            if (spyObj != null)
+            {
+                var response = _repo.ListFriends(spyGuid);
+                if (response.Count() == 0)
+                {
+                    // response is valid but empty
+                    return Ok("No friends (:\n");
+                }
+                // response is valid
+                else return Ok(response);
+            }
+            // spy not found
+            else return NotFound($"Spy with id: {spyGuid} not found");
+
+        }
     }
 }

--- a/SpyDuh.API/Repositories/SpyRepo.cs
+++ b/SpyDuh.API/Repositories/SpyRepo.cs
@@ -29,11 +29,46 @@ namespace SpyDuh.API.Repositories
                 Friends = new List<Guid> {},
                 Enemies = new List<Guid> {},
                 Handlers = new List<Guid> {}
+            },
+             new Spy
+            {
+                Name = "Vadim Kirpichenko",
+                Id = Guid.NewGuid(),
+                Skills = new List<SpySkills> {SpySkills.Alcoholic, SpySkills.DefensiveDriving, SpySkills.Hacker, SpySkills.Interrogation},
+                Services = new List<SpyServices> {SpyServices.Framing, SpyServices.IntelligenceGathering},
+                Friends = new List<Guid> {},
+                Enemies = new List<Guid> {},
+                Handlers = new List<Guid> {}
             }
         };
         internal IEnumerable<Spy> GetAll()
         {
             return _spies;
+        }
+
+        internal Spy GetSpy(Guid spyGuid)
+        {
+            return _spies.FirstOrDefault(spy => spy.Id == spyGuid);
+        }
+
+        internal IEnumerable<Spy> ListFriends(Guid spyGuid)
+        {
+            var spyObj = _spies.FirstOrDefault(spy => spy.Id == spyGuid);
+            var friendList = new List<Spy>();
+            if (spyObj != null && spyObj.Friends.Count > 0)
+            {
+                // loop through the list of friend Id's and retrieve the full friend objects
+                // and add them to a list.
+                foreach (var friendGuid in spyObj.Friends)
+                {
+                    var friendObj = _spies.FirstOrDefault(spy => spy.Id == friendGuid);
+                    if (friendObj != null)
+                    {
+                        friendList.Add(friendObj);
+                    }
+                }
+            }
+            return friendList;
         }
     }
 }


### PR DESCRIPTION
Adding paths in SpyController to add friends and list friends.
To test, copy and past the spy Id and the friend spy Id into the spyGuid and friendGuid fields in swagger.
Try adding a friend a second time to test for an error.
Try testing with invalid Guids in both the add friend patch and list friend get requests.